### PR TITLE
#24 feat(SSLPinning) : SSL Pinning을 우리 서버의 공개키로 설정

### DIFF
--- a/app/src/main/java/com/nobody/campick/services/network/APIService.kt
+++ b/app/src/main/java/com/nobody/campick/services/network/APIService.kt
@@ -26,6 +26,13 @@ object APIService {
 
     @PublishedApi
     internal val client = OkHttpClient.Builder()
+        .certificatePinner(
+            CertificatePinner.Builder()
+                .add("campick.shop","sha256/zl7w9TnvVV4VXqpG2nIB3V" +
+                        "" +
+                        "4iapuAuk2+PMBmZl3lZVE=")
+                .build()
+        )
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .writeTimeout(30, TimeUnit.SECONDS)


### PR DESCRIPTION
## Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #24 

## 추가하려는 기능에 대해 설명해주세요
- campick.shop 에 대해 인증서의 해시값을 사전 등록된 공개키를 통해 검증합니다

## 기능 설명

- 중간자 공격을 방어하기 위해 CA에서 발행하는 인증서를 받아오면 앱 패키지 내에 미리 등록된 campick 서버의 공개키를 통해서 우리의 서버인지 검증을 합니다.
- campick 서버의 공개키를 등록하기 위해 http 라이브러리인 Okhttp의 설정에 저희 서버의 공개키를 추가했습니다.


## 참고 자료
- 1번자료 : [Alamofire 공식 문서 중 ServerTrustManager 항목](https://github.com/Alamofire/Alamofire/blob/master/Documentation/AdvancedUsage.md#session)
- 2번 자료 : [Apple Developer 공식문서](https://developer.apple.com/documentation/security/preventing-insecure-network-connections#Ensure-the-Network-Server-Meets-Minimum-Requirements)

